### PR TITLE
Add README.md documentation for setting your api key

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,16 @@ Google Maps Geocoding API has a limitation that prohibits querying their geocodi
 
 ## Examples
 
-### Geocode
+### Set API Key
+
+You'll want to set an api key for the Mapquest API to go into production.
+```golang
+// this is the testing key used in `go test`
+SetAPIKey("Fmjtd%7Cluub256alu%2C7s%3Do5-9u82ur")
 ```
+
+### Geocode
+```golang
   query := "Seattle WA"
   lat, lng := geocoder.Geocode(query)
   
@@ -31,7 +39,7 @@ Google Maps Geocoding API has a limitation that prohibits querying their geocodi
 ```
 
 ### Reverse Geocode
-```
+```golang
   address := geocoder.ReverseGeocode(47.6064, -122.330803)
 
   address.Street 	        // 542 Marion St   
@@ -44,7 +52,7 @@ Google Maps Geocoding API has a limitation that prohibits querying their geocodi
 ```
 
 ### Directions
-```
+```golang
   directions := NewDirections("Amsterdam,Netherlands", []string{"Antwerp,Belgium"})
   results, err := directions.Get()
   route := results.Route

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Google Maps Geocoding API has a limitation that prohibits querying their geocodi
 ### Set API Key
 
 You'll want to set an api key for the Mapquest API to go into production.
-```golang
+```go
 // this is the testing key used in `go test`
 SetAPIKey("Fmjtd%7Cluub256alu%2C7s%3Do5-9u82ur")
 ```
 
 ### Geocode
-```golang
+```go
   query := "Seattle WA"
   lat, lng := geocoder.Geocode(query)
   
@@ -39,7 +39,7 @@ SetAPIKey("Fmjtd%7Cluub256alu%2C7s%3Do5-9u82ur")
 ```
 
 ### Reverse Geocode
-```golang
+```go
   address := geocoder.ReverseGeocode(47.6064, -122.330803)
 
   address.Street 	        // 542 Marion St   
@@ -52,7 +52,7 @@ SetAPIKey("Fmjtd%7Cluub256alu%2C7s%3Do5-9u82ur")
 ```
 
 ### Directions
-```golang
+```go
   directions := NewDirections("Amsterdam,Netherlands", []string{"Antwerp,Belgium"})
   results, err := directions.Get()
   route := results.Route


### PR DESCRIPTION
There was no documentation about setting your API key for the mapquest API and seeing as most people will want to do this I added an example to the README. Pretty self explanatory but people might want to know the function name

:smile: