### PR TITLE
Add, test, and document error handling on geocoding and reverse geocoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ SetAPIKey("Fmjtd%7Cluub256alu%2C7s%3Do5-9u82ur")
 ### Geocode
 ```go
   query := "Seattle WA"
-  lat, lng := geocoder.Geocode(query)
+  lat, lng, err := geocoder.Geocode(query)
+  if err != nil {
+    panic("THERE WAS SOME ERROR!!!!!")
+  }
   
   // 47.6064, -122.330803
  
@@ -40,7 +43,10 @@ SetAPIKey("Fmjtd%7Cluub256alu%2C7s%3Do5-9u82ur")
 
 ### Reverse Geocode
 ```go
-  address := geocoder.ReverseGeocode(47.6064, -122.330803)
+  address, err := geocoder.ReverseGeocode(47.6064, -122.330803)
+  if err != nil {
+    panic("THERE WAS SOME ERROR!!!!!")
+  }
 
   address.Street 	        // 542 Marion St   
   address.City 		        // Seattle
@@ -55,12 +61,23 @@ SetAPIKey("Fmjtd%7Cluub256alu%2C7s%3Do5-9u82ur")
 ```go
   directions := NewDirections("Amsterdam,Netherlands", []string{"Antwerp,Belgium"})
   results, err := directions.Get()
+  if err != nil {
+    panic("THERE WAS SOME ERROR!!!!!")
+  }
+
   route := results.Route
   time:= route.Time
   legs:= route.Legs
   distance:= route.Distance
+
   // or get distance with this shortcut
+  //
+  // use "k" to return result in km
+  // use "m" to return result in miles
   distance, err := directions.Distance("k")
+  if err != nil {
+    panic("THERE WAS SOME ERROR!!!!!")
+  }
 ```
 
 ## Documentation

--- a/geocoding_test.go
+++ b/geocoding_test.go
@@ -1,8 +1,6 @@
 package geocoder
 
-import (
-	"testing"
-)
+import "testing"
 
 const (
 	city       = "Seattle"
@@ -18,24 +16,37 @@ const (
 
 func TestGeocode(t *testing.T) {
 	query := "Seattle WA"
-	lat, lng := Geocode(query)
+	lat, lng, err := Geocode(query)
+	if err != nil {
+		t.Errorf("Seattle: Expected error to be nil ~ Recieved %v", err)
+	}
 
 	if lat != seattleLat || lng != seattleLng {
-		t.Errorf("Seattle: Expected %f, %f ~ Received %f, %f", seattleLat, seattleLng, lat, lng)
+		t.Errorf("Seattle: Expected (%f, %f) ~ Received (%f, %f)", seattleLat, seattleLng, lat, lng)
 	}
 }
 
 func TestReverseGeoCode(t *testing.T) {
-	address := ReverseGeocode(seattleLat, seattleLng)
+	address, err := ReverseGeocode(seattleLat, seattleLng)
+	if err != nil {
+		t.Errorf("Seattle (reverse): Expected error to be nil ~ Recieved %v", err)
+	}
 
-	if address.City != city || address.State != state || address.PostalCode != postalCode {
+	if address != nil && address.City != city || address.State != state || address.PostalCode != postalCode {
 		t.Errorf("Seattle (reverse): Expected %s %s %s ~ Received %s %s %s",
 			city, state, postalCode, address.City, address.State, address.PostalCode)
 	}
 }
 
 func TestBatchGeocode(t *testing.T) {
-	latLngs := BatchGeocode([]string{"Antwerp,Belgium", "Beijing,China"})
+	latLngs, err := BatchGeocode([]string{"Antwerp,Belgium", "Beijing,China"})
+	if err != nil {
+		t.Errorf("Seattle (reverse): Expected error to be nil ~ Recieved %v", err)
+	}
+
+	if len(latLngs) != 2 {
+		t.Fatalf("Batch: Expected len(batch) to be 2, got %v", latLngs)
+	}
 	antwerp := latLngs[0]
 	if antwerp.Lat != antwerpLat || antwerp.Lng != antwerpLng {
 		t.Errorf("Antwerp: Expected %f, %f ~ Received %f, %f", antwerpLat, antwerpLng, antwerp.Lat, antwerp.Lng)
@@ -43,5 +54,52 @@ func TestBatchGeocode(t *testing.T) {
 	beijing := latLngs[1]
 	if beijing.Lat != beijingLat || beijing.Lng != beijingLng {
 		t.Errorf("Beijng: Expected %f, %f ~ Received %f, %f", beijingLat, beijingLng, beijing.Lat, beijing.Lng)
+	}
+}
+
+func TestGeocodeShouldFail(t *testing.T) {
+	query := "Seattle WA"
+	// set a bad api key
+	SetAPIKey("bad api key that doesn't exist, hopefully!")
+	lat, lng, err := Geocode(query)
+	SetAPIKey(apiKey)
+
+	if err == nil {
+		t.Errorf("Seattle: Expected error to not be nil ~ Recieved %v", err)
+	}
+
+	if lat != 0 || lng != 0 {
+		t.Errorf("Seattle: Expected (0, 0) ~ Received (%f, %f)", lat, lng)
+	}
+}
+
+func TestReverseGeoCodeShouldFail(t *testing.T) {
+	// set a bad api key
+	SetAPIKey("bad api key that doesn't exist, hopefully!")
+	address, err := ReverseGeocode(seattleLat, seattleLng)
+	SetAPIKey(apiKey)
+
+	if err == nil {
+		t.Errorf("Seattle (reverse): Expected error to not be nil ~ Recieved %v", err)
+	}
+
+	if address != nil {
+		t.Errorf("Seattle (reverse): Expected address to be nil ~ Received %v",
+			address)
+	}
+}
+
+func TestBatchGeocodeShouldFail(t *testing.T) {
+	// set a bad api key
+	SetAPIKey("bad api key that doesn't exist, hopefully!")
+	latLngs, err := BatchGeocode([]string{"Antwerp,Belgium", "Beijing,China"})
+	SetAPIKey(apiKey)
+
+	if err == nil {
+		t.Errorf("Batch: Expected error to be nil ~ Recieved %v", err)
+	}
+
+	if len(latLngs) != 0 {
+		t.Errorf("Batch: Expected len(batch) to be 0, got %v", latLngs)
 	}
 }


### PR DESCRIPTION
I added error handling in all of the geocoding related functions (the directions functions already had it) and changed the current tests to check for this. I added new tests where I set the api key to an invalid value and then make the request, and then reset the api key. The only potential issue with this down the line is if you have multiple tests running in parallel and you the api key changes midway through a test where it wasn't supposed to, but this is a problem with the current use of the global variable, and could only really be solved by passing an optional 'APIKey' param into all the functions and if it's "" then just use the global var. This is what I'm doing at work for passing in mock databases to dao layer functions but it might be too hectic for a utility library. All said, it works like it is now but you may want to look out for this issue in the future. The functions will always work, the testing strategy might need to change is what I'm saying.