### PR TITLE
Add FullGeocode method.

### DIFF
--- a/geocoder.go
+++ b/geocoder.go
@@ -39,3 +39,48 @@ type Location struct {
 	Type        string `json:"type"`
 	DragPoint   bool   `json:"dragPoint"`
 }
+
+type GeocodingResult struct {
+	Info struct {
+		StatusCode int `json:"statuscode"`
+		Copyright  struct {
+			Text         string `json:"text"`
+			ImageUrl     string `json:"imageUrl"`
+			ImageAltText string `json:"imageAltText"`
+		} `json:"copyright"`
+	} `json:"info"`
+	Options struct {
+		MaxResults        int  `json:"maxResults"`
+		ThumbMaps         bool `json:"thumbMaps"`
+		IgnoreLatLngInput bool `json:"ignoreLatLngInput"`
+	} `json:"options"`
+	Results []struct {
+		ProvidedLocation struct {
+			Location string `json:"location"`
+		} `json:"providedLocation"`
+		Locations []struct {
+			Street             string `json:"street"`
+			AdminArea6         string `json:"adminArea6"`
+			AdminArea6Type     string `json:"adminArea6Type"`
+			AdminArea5         string `json:"adminArea5"`
+			AdminArea5Type     string `json:"adminArea5Type"`
+			AdminArea4         string `json:"adminArea4"`
+			AdminArea4Type     string `json:"adminArea4Type"`
+			AdminArea3         string `json:"adminArea3"`
+			AdminArea3Type     string `json:"adminArea3Type"`
+			AdminArea1         string `json:"adminArea1"`
+			AdminArea1Type     string `json:"adminArea1Type"`
+			PostalCode         string `json:"postalCode"`
+			GeocodeQualityCode string `json:"geocodeQualityCode"`
+			GeocodeQuality     string `json:"geocodeQuality"`
+			DragPoint          bool   `json:"dragPoint"`
+			SideOfStreet       string `json:"sideOfStreet"`
+			LinkId             string `json:"linkId"`
+			UnknownInput       string `json:"unknownInput"`
+			Type               string `json:"type"`
+			LatLng             LatLng `json:"latLng"`
+			DisplayLatLng      LatLng `json:"displayLatLng"`
+			MapUrl             string `json:"mapUrl"`
+		} `json:"locations"`
+	} `json:"results"`
+}

--- a/geocoding.go
+++ b/geocoding.go
@@ -5,7 +5,7 @@ Reference: http://open.mapquestapi.com/geocoding/
 Example:
 
 lat, lng := Geocode("Seattle WA")
-address := ReverseGeocode(47.603561, -122.329437)
+location, err := ReverseGeocode(47.603561, -122.329437)
 
 */
 
@@ -52,6 +52,29 @@ func Geocode(address string) (float64, float64, error) {
 	}
 
 	return lat, lng, nil
+}
+
+// FullGeocode returns the full geocoding response including reverse-geocoded
+// location
+func FullGeocode(address string) (*GeocodingResult, error) {
+	// Query Provider
+	resp, err := http.Get(geocodeURL + url.QueryEscape(address) + "&key=" + apiKey)
+
+	if err != nil {
+		return nil, fmt.Errorf("Error geocoding address: <%v>", err)
+	}
+
+	defer resp.Body.Close()
+
+	// Decode our JSON results
+	var result GeocodingResult
+	err = decoder(resp).Decode(&result)
+
+	if err != nil {
+		return nil, fmt.Errorf("Error decoding geocoding result: <%v>", err)
+	}
+
+	return &result, nil
 }
 
 // ReverseGeocode returns the address for a certain latitude and longitude


### PR DESCRIPTION
Thanks for the library! It is very useful.

I found myself needing the geocoded city/state to go from, for example, "boston" to "Boston, MA" when displaying the location. This can be obtained via a reverse geocoding call but that means two calls are needed total.

This PR adds a FullGeocode method whihc returns all of the data MapQuest makes available during geocoding, including the city/state/etc. location information.

I can add docs if this PR is OK.